### PR TITLE
docs: CLAUDE.mdにPost-Merge Workflowを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,23 @@ Before creating any PR, ALWAYS:
 4. Ensure all intended changes are included in commits
 5. Check if formatters/linters modified files during commit
 
+### Post-Merge Workflow
+When the user informs you that a PR has been merged:
+1. **Immediately switch to main branch**: `git checkout main`
+2. **Pull the latest changes**: `git pull origin main`
+3. **Verify the merge**: Check that all expected changes are present
+4. **Clean up**: Delete the local feature branch if no longer needed
+
+Example:
+```bash
+# After user says "マージしました" or "merged"
+git checkout main
+git pull origin main
+git branch -d feature-branch-name  # Optional: clean up local branch
+```
+
+This ensures you're always working with the latest code and prevents conflicts.
+
 ## Common Development Tasks
 
 ### Adding a New Manager


### PR DESCRIPTION
## 概要
ユーザーがPRのマージを報告した際の標準的な作業フローをCLAUDE.mdに追加しました。

## 追加内容

### Post-Merge Workflow
以下の手順を文書化：

1. **mainブランチへの即座の切り替え**
   ```bash
   git checkout main
   ```

2. **最新変更の取得**
   ```bash
   git pull origin main
   ```

3. **マージの確認**
   - 期待した変更がすべて含まれているか確認

4. **ローカルブランチのクリーンアップ（オプション）**
   ```bash
   git branch -d feature-branch-name
   ```

## 背景
ユーザーが「マージしました」と報告した際に、自動的にmainブランチに戻って最新の変更を取得することで：
- 常に最新のコードベースで作業できる
- 将来的なコンフリクトを防げる
- 作業の一貫性を保てる

## 該当箇所
CLAUDE.md の「Development Guidelines」セクションに追加

🤖 Generated with Claude Code